### PR TITLE
426 add method for querying customers with customerID

### DIFF
--- a/src/Builders/Builder.php
+++ b/src/Builders/Builder.php
@@ -21,6 +21,7 @@ class Builder
 	protected $model;
 	protected $request;
 
+
 	public function __construct( Request $request ) {
 		$this->request = $request;
 	}

--- a/src/Builders/CustomerBuilder.php
+++ b/src/Builders/CustomerBuilder.php
@@ -36,4 +36,21 @@ class CustomerBuilder extends Builder
 
         return $items;
     }
+
+    /**
+     * @param int $id
+     *
+     * @return KgBot\Billy\Models\Customer
+     */
+    public function getWithID( $id ) 
+    {
+        return $this->request->handleWithExceptions( function () use ( $id ) {
+
+            $response     = $this->request->client->get( "{$this->entity}/{$id}" );
+            $responseData = json_decode( (string) $response->getBody() );
+
+            return new $this->model( $this->request, $responseData->contact );
+        } );
+    }
+
 }


### PR DESCRIPTION
The reason i added this method and didnt use/overwrite the `Builder@find` method was because this line of the find method `$responseData->values()->{Str::singular( $this->entity )}` was causing an error with the data returned from Billy using the get method with an id, and i didnt overwrite the find method incase it was being used elsewhere